### PR TITLE
Add option to skip check for article elements

### DIFF
--- a/main_content_extractor/main_content_extractor.py
+++ b/main_content_extractor/main_content_extractor.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup, Tag
 from typing import List, Union
-from html2text import html2text
+import html2text
 from .trafilatura_extends import TrafilaturaExtends
 
 REMOVE_ELEMENT_LIST_DEFAULT: List[str] = [
@@ -21,6 +21,7 @@ class MainContentExtractor:
         output_format: str = "html",
         include_links: bool = True,
         ref_extraction_method: dict = {},
+        **html2text_kwargs
     ) -> str:
         """
         Extracts the main content from an HTML string.
@@ -30,27 +31,28 @@ class MainContentExtractor:
             output_format: The format of the extracted content (html, text, markdown).
             include_links: Whether to include links in the extracted content.
             ref_extraction_method: A dictionary to store the reference to the extraction method.
-            
+            **html2text_kwargs: Additional keyword arguments to be passed to the html2text library for markdown conversion.
+                View options here: https://github.com/Alir3z4/html2text/blob/master/docs/usage.md
+
         Returns:
             The extracted main content as a string.
         """
         valid_formats = ["html", "text", "markdown"]
-        
         if output_format not in valid_formats:
-            raise ValueError(f"Invalid output_format: {output_format}. Valid formats are: {', '.join(valid_formats)}.")
-    
+            raise ValueError(f"Invalid output_format: {output_format}. Valid formats are: "
+                             f"{', '.join(valid_formats)}.")
+
         soup = BeautifulSoup(html, "html.parser")
-        soup = MainContentExtractor._remove_elements(soup, REMOVE_ELEMENT_LIST_DEFAULT)
+        soup = MainContentExtractor._remove_elements(
+            soup, REMOVE_ELEMENT_LIST_DEFAULT)
 
         main_content = soup.find("main")
-
         result_html = None
         extraction_method = None
 
         if main_content:
             extraction_method = "main_element"
             articles = main_content.find_all("article")
-
             if articles:
                 result_html = "".join(str(article) for article in articles)
             else:
@@ -74,19 +76,24 @@ class MainContentExtractor:
 
         if result_html:
             soup = BeautifulSoup(result_html, "html.parser")
-
             if ref_extraction_method is not None:
                 ref_extraction_method["extraction_method"] = extraction_method
 
             if output_format == "text":
                 return soup.get_text(strip=True)
-            
-            if include_links == False:
-                soup = MainContentExtractor._remove_elements_keep_text(soup, ["a","img"])
+
+            if not include_links:
+                soup = MainContentExtractor._remove_elements_keep_text(soup, [
+                    "a", "img"])
+
             if output_format == "html":
                 return soup.prettify()
             elif output_format == "markdown":
-                return html2text(str(soup))
+                # Convert HTML to Markdown using html2text with configuration
+                mdconverter = html2text.HTML2Text(
+                    **html2text_kwargs
+                )
+                return mdconverter.handle(str(soup))
 
     def extract_links(html_content: str, **kwargs) -> dict:
         """


### PR DESCRIPTION
I added an argument to MainContentExtractor.extract() that bypasses the check for article elements and causes the function to use Trafilatura if there is no main element found in the html. I think this is helpful because I've found that some webpages have article elements that don't contain the page's main content and the main content is found elsewhere on the webpage. 

A further improvement to the logic could be using the contents of article elements only if it contains text above a minimum character count, or above a minimum percentage of all the text found on the webpage, but this is just an idea.